### PR TITLE
fix: exclude tslib from externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@gioboa/vite-module-federation",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gioboa/vite-module-federation",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "husky": "^8.0.0",
         "microbundle": "^0.15.1",
         "mime-types": "^2.1.35",
         "pretty-quick": "^3.1.3",
+        "rimraf": "^3.0.2",
         "vite": "^3.1.3"
       },
       "peerDependencies": {
@@ -5906,6 +5907,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
@@ -10952,6 +10968,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "rollup": {
       "version": "2.79.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gioboa/vite-module-federation",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Vite/Rollup plugin for Module Federation",
   "type": "module",
   "source": "src/index.ts",
@@ -13,7 +13,7 @@
     "prepare": "husky install",
     "format": "pretty-quick",
     "dev": "microbundle watch",
-    "build": "rm -rf lib && microbundle --no-sourcemap"
+    "build": "rimraf lib && microbundle --no-sourcemap"
   },
   "repository": {
     "type": "git",
@@ -42,6 +42,7 @@
     "microbundle": "^0.15.1",
     "mime-types": "^2.1.35",
     "pretty-quick": "^3.1.3",
+    "rimraf": "^3.0.2",
     "vite": "^3.1.3"
   }
 }

--- a/src/dev-externals-mixin.ts
+++ b/src/dev-externals-mixin.ts
@@ -1,4 +1,5 @@
 import { federationBuilder } from '@softarc/native-federation/build.js';
+import { filterExternals } from './externals-skip-list';
 
 // see: https://github.com/vitejs/vite/issues/6393#issuecomment-1006819717
 
@@ -7,7 +8,10 @@ export const devExternalsMixin = {
   config(config) {
     config.optimizeDeps = {
       ...(config.optimizeDeps ?? {}),
-      exclude: [...(config.optimizeDeps?.exclude ?? []), ...federationBuilder.externals],
+      exclude: [
+        ...(config.optimizeDeps?.exclude ?? []),
+        ...filterExternals(federationBuilder.externals),
+      ],
     };
   },
   configResolved(resolvedConfig) {
@@ -19,7 +23,7 @@ export const devExternalsMixin = {
     });
   },
   resolveId: (id) => {
-    if (federationBuilder.externals.includes(id)) {
+    if (filterExternals(federationBuilder.externals).includes(id)) {
       return { id, external: true };
     }
   },

--- a/src/externals-skip-list.ts
+++ b/src/externals-skip-list.ts
@@ -1,0 +1,5 @@
+export const externalsSkipList = new Set(['tslib']);
+
+export function filterExternals(deps: string[]): string[] {
+  return deps.filter((d) => !externalsSkipList.has(d));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,14 @@ import * as path from 'path';
 import mime from 'mime-types';
 import { Connect, ViteDevServer } from 'vite';
 import { devExternalsMixin } from './dev-externals-mixin';
+import { filterExternals } from './externals-skip-list';
 
 export const federation = async (params: BuildHelperParams) => {
   return {
     name: 'vite-module-federation', // required, will show up in warnings and errors
     async options(o: unknown) {
       await federationBuilder.init(params);
-      o!['external'] = federationBuilder.externals;
+      o!['external'] = filterExternals(federationBuilder.externals);
     },
     async closeBundle() {
       await federationBuilder.build();


### PR DESCRIPTION
this prevents an hen/egg issue as ``tslib`` might already be used in the entry point that calls ``initFederation``. Hence, we cannot have it as an external because externals are resolved via the import map created by ``initFederation``.